### PR TITLE
Add a way to pick which option is currently selected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ help:
 build:
 	elm make --warn src/Main.elm --output=$(OUT)
 
+bump:
+	elm package bump
+
 clean:
 	$(NUKE) elm-stuff/build-artifacts $(OUT)
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "Helpers for building Select inputs in Elm",
     "repository": "https://github.com/lgastako/elm-select.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "Select"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "summary": "Helpers for building Select inputs in Elm",
     "repository": "https://github.com/lgastako/elm-select.git",
     "license": "BSD3",

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,7 +1,6 @@
 module Main exposing (main)
 
-import Html exposing (Html, br, div, text)
-import Html.App exposing (beginnerProgram)
+import Html exposing (Html, beginnerProgram, br, div, text)
 import Html.Attributes exposing (style)
 import Select
 
@@ -69,14 +68,14 @@ emptyModel =
 update : Msg -> Model -> Model
 update msg model =
     (case msg of
-        NewDay day' ->
-            { model | day = day' }
+        NewDay day_ ->
+            { model | day = day_ }
 
-        NewDirection direction' ->
-            { model | direction = direction' }
+        NewDirection direction_ ->
+            { model | direction = direction_ }
 
-        NewShape shape' ->
-            { model | shape = shape' }
+        NewShape shape_ ->
+            { model | shape = shape_ }
     )
         |> Debug.log "update.result"
 
@@ -115,7 +114,7 @@ view model =
             ]
 
 
-main : Program Never
+main : Program Never Model Msg
 main =
     beginnerProgram
         { model = emptyModel

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -1,22 +1,22 @@
-module Select exposing (from, from_)
+module Select exposing (from, from_, fromSelected, fromSelected_)
 
-{-| This module provides the `from` (and more flexible `from_`) helpers to make
-working with `select` elements in Elm easier.
+{-| This module provides the `from` and `fromSelected` (and more
+flexible `from_` and `fromSelected_`) helpers to make working
+with `select` elements in Elm easier.
 
 [See full examples in github](https://github.com/lgastako/elm-select/blob/master/src/Main.elm)
 
-# Helpers
-@docs from, from_
+@docs from, from_, fromSelected, fromSelected_
 
 -}
 
 import Html exposing (Html, option, select, text)
-import Html.Attributes exposing (value)
+import Html.Attributes exposing (value, selected)
 import Html.Events exposing (onInput)
 
 
 {-| Convert a list of values and stringifying function for values of that type
-into a `select` element which contains as it's values the list of values.
+into a `select` element which contains as its values the list of values.
 
     from [North, South, East, West] Direction
 
@@ -32,7 +32,23 @@ from xs msg =
 
 
 {-| Convert a list of values and stringifying function for values of that type
-into a `select` element which contains as it's values the list of values.
+into a `select` element which contains as its values the list of values, with
+a specified element currently selected.
+
+    from [North, South, East, West] Direction South
+
+would produce a select element with box option values and labels being the
+string versions of four cardinal directions and which would send messages like
+`Direction North` or `Direction East` when the user selects new directions from
+the drop down. `South` would show up as the currently selected element.
+
+-}
+fromSelected : List a -> (a -> msg) -> a -> Html msg
+fromSelected xs msg sel =
+    fromSelected_ xs msg toString toString sel
+
+{-| Convert a list of values and stringifying function for values of that type
+into a `select` element which contains as its values the list of values.
 
     from_ [North, South, East, West] Direction toId toLabel
 
@@ -49,6 +65,31 @@ from_ xs msg toId toLabel =
     let
         optionize x =
             option [ (value << toId) x ]
+                [ (text << toLabel) x ]
+    in
+        select [ onInput (msg << makeFromString_ xs) ]
+            (List.map optionize xs)
+
+
+{-| Convert a list of values and stringifying function for values of that type
+into a `select` element which contains as its values the list of values, with
+a specified element currently selected.
+
+    fromSelected_ [North, South, East, West] Direction toId toLabel South
+
+like the `from` example above, this would produce a select element with box
+option values and labels being derived from the four cardinal directions and
+which would send messages like `Direction North` or `Direction East` when the
+user selects new directions from the drop down only the ids and labels would be
+derived using the `toId` and `toLabel` functions provided instead of defaulting
+to `toString` like `from`. `South` would show up as the currently selected element.
+
+-}
+fromSelected_ : List a -> (a -> msg) -> (a -> String) -> (a -> String) -> a -> Html msg
+fromSelected_ xs msg toId toLabel sel =
+    let
+        optionize x =
+            option ([ (value << toId) x ] ++ (if x == sel then [ selected True ] else []))
                 [ (text << toLabel) x ]
     in
         select [ onInput (msg << makeFromString_ xs) ]

--- a/src/Select.elm
+++ b/src/Select.elm
@@ -1,12 +1,12 @@
-module Select exposing (from, from')
+module Select exposing (from, from_)
 
-{-| This module provides the `from` (and more flexible `from'`) helpers to make
+{-| This module provides the `from` (and more flexible `from_`) helpers to make
 working with `select` elements in Elm easier.
 
 [See full examples in github](https://github.com/lgastako/elm-select/blob/master/src/Main.elm)
 
 # Helpers
-@docs from, from'
+@docs from, from_
 
 -}
 
@@ -28,13 +28,13 @@ the drop down.
 -}
 from : List a -> (a -> msg) -> Html msg
 from xs msg =
-    from' xs msg toString toString
+    from_ xs msg toString toString
 
 
 {-| Convert a list of values and stringifying function for values of that type
 into a `select` element which contains as it's values the list of values.
 
-    from' [North, South, East, West] Direction toId toLabel
+    from_ [North, South, East, West] Direction toId toLabel
 
 like the `from` example above, this would produce a select element with box
 option values and labels being derived from the four cardinal directions and
@@ -44,14 +44,14 @@ derived using the `toId` and `toLabel` functions provided instead of defaulting
 to `toString` like `from`.
 
 -}
-from' : List a -> (a -> msg) -> (a -> String) -> (a -> String) -> Html msg
-from' xs msg toId toLabel =
+from_ : List a -> (a -> msg) -> (a -> String) -> (a -> String) -> Html msg
+from_ xs msg toId toLabel =
     let
         optionize x =
             option [ (value << toId) x ]
                 [ (text << toLabel) x ]
     in
-        select [ onInput (msg << makeFromString' xs) ]
+        select [ onInput (msg << makeFromString_ xs) ]
             (List.map optionize xs)
 
 
@@ -75,18 +75,18 @@ makeFromString xs =
         fromString
 
 
-makeFromString' : List a -> (String -> a)
-makeFromString' xs =
+makeFromString_ : List a -> (String -> a)
+makeFromString_ xs =
     let
         fromString =
             makeFromString xs
 
-        fromString' s =
+        fromString_ s =
             case fromString s of
                 Nothing ->
-                    Debug.crash "fromString returned Nothing in fromString'"
+                    Debug.crash "fromString returned Nothing in fromString_"
 
                 Just s ->
                     s
     in
-        fromString'
+        fromString_


### PR DESCRIPTION
Sorry for the messy PR. I couldn't find a branch for the 2.0.0 changes, so those are unfortunately picked up in this PR for merging to master.

This addresses issue #1 , though I'm not sure if creating entirely new functions is the best way of doing it. This might be a common enough use case that it would be worth incorporating into `from` and `from_`.